### PR TITLE
IN-1117 Removes IDs from tracks and challenges, adds `--force` to CD

### DIFF
--- a/.github/workflows/cd.main.yml
+++ b/.github/workflows/cd.main.yml
@@ -6,6 +6,7 @@ env:
 jobs:
   deploy-changes:
     name: Deploy changes
+    runs-on: ubuntu-latest
     container:
       image: instruqt/cli
       env:

--- a/.github/workflows/cd.main.yml
+++ b/.github/workflows/cd.main.yml
@@ -1,5 +1,8 @@
 name: CD
-on: pull_request
+on:
+  push:
+    branches:
+      - main
 env:
   ORGANIZATION_SLUG: templates
   INSTRUQT_TOKEN: ${{ secrets.INSTRUQT_TOKEN }}
@@ -7,10 +10,6 @@ jobs:
   deploy-changes:
     name: Deploy changes
     runs-on: ubuntu-latest
-    container:
-      image: instruqt/cli
-      env:
-        INSTRUQT_TOKEN: ${{ env.INSTRUQT_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -20,7 +19,6 @@ jobs:
 
           for track in */; do
               pushd $track
-              echo $track
-              instruqt --help
+              docker run -e INSTRUQT_TOKEN=${{ env.INSTRUQT_TOKEN }} --workdir="/track" --mount type=bind,source="$(pwd)",target=/track instruqt/cli track push --force
               popd
-          done\
+          done

--- a/.github/workflows/cd.main.yml
+++ b/.github/workflows/cd.main.yml
@@ -1,15 +1,15 @@
 name: CD
-on:
-  push:
-    branches:
-      - main
+on: pull_request
 env:
   ORGANIZATION_SLUG: templates
   INSTRUQT_TOKEN: ${{ secrets.INSTRUQT_TOKEN }}
 jobs:
   deploy-changes:
     name: Deploy changes
-    runs-on: ubuntu-latest
+    container:
+      image: instruqt/cli
+      env:
+        INSTRUQT_TOKEN: ${{ env.INSTRUQT_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -19,6 +19,7 @@ jobs:
 
           for track in */; do
               pushd $track
-              docker run -e INSTRUQT_TOKEN=${{ env.INSTRUQT_TOKEN }} --workdir="/track" --mount type=bind,source="$(pwd)",target=/track instruqt/cli track push --force
+              echo $track
+              instruqt --help
               popd
-          done
+          done\

--- a/.github/workflows/cd.main.yml
+++ b/.github/workflows/cd.main.yml
@@ -19,6 +19,6 @@ jobs:
 
           for track in */; do
               pushd $track
-              docker run -e INSTRUQT_TOKEN=${{ env.INSTRUQT_TOKEN }} --workdir="/track" --mount type=bind,source="$(pwd)",target=/track instruqt/cli track push
+              docker run -e INSTRUQT_TOKEN=${{ env.INSTRUQT_TOKEN }} --workdir="/track" --mount type=bind,source="$(pwd)",target=/track instruqt/cli track push --force
               popd
           done

--- a/aws-cloud-account/01-aws-ec2-create/assignment.md
+++ b/aws-cloud-account/01-aws-ec2-create/assignment.md
@@ -1,6 +1,5 @@
 ---
 slug: aws-ec2-create
-id: 8mbkksmjakif
 type: challenge
 title: Create an AWS EC2 instance
 teaser: Every cloud starts from VM

--- a/aws-cloud-account/02-aws-ec2-delete/assignment.md
+++ b/aws-cloud-account/02-aws-ec2-delete/assignment.md
@@ -1,6 +1,5 @@
 ---
 slug: aws-ec2-delete
-id: tlod6cx1ytfr
 type: challenge
 title: AWS EC2 instance deletion
 teaser: Use AWS console to manage your EC2 virtual machine.

--- a/aws-cloud-account/track.yml
+++ b/aws-cloud-account/track.yml
@@ -23,4 +23,3 @@ developers:
 - vadym@instruqt.com
 private: false
 published: true
-checksum: "13254736193028753480"

--- a/aws-cloud-account/track.yml
+++ b/aws-cloud-account/track.yml
@@ -1,5 +1,4 @@
 slug: aws-cloud-account
-id: 0ytrmq5i2xlu
 type: track
 title: AWS Cloud Account
 teaser: Learn how to build tracks with an AWS account

--- a/container/01-creating-a-directory/assignment.md
+++ b/container/01-creating-a-directory/assignment.md
@@ -1,6 +1,5 @@
 ---
 slug: creating-a-directory
-id: 5y3ow5tpeafn
 type: challenge
 title: Creating a directory
 teaser: Learn how to create directory

--- a/container/track.yml
+++ b/container/track.yml
@@ -15,4 +15,3 @@ developers:
 - matthisk@instruqt.com
 private: false
 published: true
-checksum: "640984014694652024"

--- a/container/track.yml
+++ b/container/track.yml
@@ -1,5 +1,4 @@
 slug: container
-id: ntbwtjuarm8w
 type: track
 title: Sandbox container
 teaser: Get started quickly with just one container-based sandbox host.

--- a/docker-vm/01-building-an-image/assignment.md
+++ b/docker-vm/01-building-an-image/assignment.md
@@ -1,6 +1,5 @@
 ---
 slug: building-an-image
-id: 5pfctcg5dylf
 type: challenge
 title: Building a container image
 teaser: Learn how to build an image using a Dockerfile

--- a/docker-vm/02-running-a-container/assignment.md
+++ b/docker-vm/02-running-a-container/assignment.md
@@ -1,6 +1,5 @@
 ---
 slug: running-a-container
-id: fty3fwbuybcd
 type: challenge
 title: Starting a container
 teaser: Start the container image you've just built

--- a/docker-vm/track.yml
+++ b/docker-vm/track.yml
@@ -21,4 +21,3 @@ developers:
 - vadym@instruqt.com
 private: false
 published: true
-checksum: "12703814078892311708"

--- a/docker-vm/track.yml
+++ b/docker-vm/track.yml
@@ -1,5 +1,4 @@
 slug: docker-vm
-id: uzxqici3wh6h
 type: track
 title: Sandbox virtual machine
 teaser: Use a virtual machine (VM) as a sandbox host

--- a/helm/01-check-nginx/assignment.md
+++ b/helm/01-check-nginx/assignment.md
@@ -1,6 +1,5 @@
 ---
 slug: check-nginx
-id: o5uzceb0lsbs
 type: challenge
 title: Check that the NGINX chart is installed
 teaser: A setup script has used helm to install an NGINX chart. Verify that it worked!

--- a/helm/track.yml
+++ b/helm/track.yml
@@ -1,5 +1,4 @@
 slug: helm
-id: 5qfxre4keecb
 type: track
 title: Helm chart
 teaser: Learn how to install helm charts with Instruqt.

--- a/helm/track.yml
+++ b/helm/track.yml
@@ -19,4 +19,3 @@ developers:
   - gerson@instruqt.com
 private: false
 published: true
-checksum: "9979754119823216916"

--- a/kubernetes-cluster/01-explore-kubernetes/assignment.md
+++ b/kubernetes-cluster/01-explore-kubernetes/assignment.md
@@ -1,6 +1,5 @@
 ---
 slug: explore-kubernetes
-id: e6izfra7vgpl
 type: challenge
 title: Explore Kubernetes
 teaser: Explore Kubernetes

--- a/kubernetes-cluster/track.yml
+++ b/kubernetes-cluster/track.yml
@@ -23,4 +23,3 @@ developers:
 private: false
 published: true
 show_timer: true
-checksum: "438818138343394971"

--- a/kubernetes-cluster/track.yml
+++ b/kubernetes-cluster/track.yml
@@ -1,5 +1,4 @@
 slug: kubernetes-cluster
-id: 2lb3tdzl8dan
 type: track
 title: Multi-node Kubernetes cluster
 teaser: Setup a Kubernetes cluster on multiple sandbox hosts

--- a/kubernetes/01-deploying-nginx/assignment.md
+++ b/kubernetes/01-deploying-nginx/assignment.md
@@ -1,6 +1,5 @@
 ---
 slug: deploying-nginx
-id: cm3mp385y082
 type: challenge
 title: Deploy NGINX
 teaser: Everything starts with a web server

--- a/kubernetes/02-exposing-nginx/assignment.md
+++ b/kubernetes/02-exposing-nginx/assignment.md
@@ -1,6 +1,5 @@
 ---
 slug: exposing-nginx
-id: 7oqpyx3avcwm
 type: challenge
 title: Expose the NGINX service
 teaser: Use a NodePort to expose the NGINX web server

--- a/kubernetes/03-showing-the-service/assignment.md
+++ b/kubernetes/03-showing-the-service/assignment.md
@@ -1,6 +1,5 @@
 ---
 slug: showing-the-service
-id: qh8v1izdymkq
 type: challenge
 title: Viewing NGINX
 teaser: View the service in an embedded tab

--- a/kubernetes/04-kubernetes-dashboard/assignment.md
+++ b/kubernetes/04-kubernetes-dashboard/assignment.md
@@ -1,6 +1,5 @@
 ---
 slug: kubernetes-dashboard
-id: lz3wgs4qaigx
 type: challenge
 title: Kubernetes Dashboard
 teaser: Expose the kubernetes dashboard in a tab

--- a/kubernetes/track.yml
+++ b/kubernetes/track.yml
@@ -18,4 +18,3 @@ developers:
 - vadym@instruqt.com
 private: false
 published: true
-checksum: "17976426375823579114"

--- a/kubernetes/track.yml
+++ b/kubernetes/track.yml
@@ -1,5 +1,4 @@
 slug: kubernetes
-id: e9kwwum26pn3
 type: track
 title: Kubernetes
 teaser: Learn how to build Kubernetes-based tracks with this template

--- a/vscode-typescript/01-passing-tests/assignment.md
+++ b/vscode-typescript/01-passing-tests/assignment.md
@@ -1,6 +1,5 @@
 ---
 slug: passing-tests
-id: kgsrl1diqfpz
 type: challenge
 title: Passing tests
 teaser: Learn how to run and pass tests

--- a/vscode-typescript/track.yml
+++ b/vscode-typescript/track.yml
@@ -1,5 +1,4 @@
 slug: vscode-typescript
-id: 0dxngfkws4op
 type: track
 title: VSCode & TypeScript
 teaser: Edit and test TypeScript applications in VSCode

--- a/vscode-typescript/track.yml
+++ b/vscode-typescript/track.yml
@@ -22,4 +22,3 @@ developers:
 - vadym@instruqt.com
 private: false
 published: true
-checksum: "4690624364675616768"


### PR DESCRIPTION
Let's CD deploy tracks with the `--force` flag, making version control the definite source of truth. Makes tracks environment agnostic, so they can be deployed to both dev and prod if needed.

## Changes
- Removes ids for tracks and challenges.
- Adds `--force` flag to CD.