### PR TITLE
Add a simple gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# OS generated.
+.DS_Store
+
+# IDE generated.
+.idea
+.vscode


### PR DESCRIPTION
This adds a simple `.gitigore` file to the templates repository.

Currently we can leak IDE and OS files into the repository accidentally. Seeing that this repository mainly consists of yaml files I don't suspect we need to worry about any additional binaries that might be committed accidentally.