### PR TITLE
Add template that shows how to make use of allow external ingress

### DIFF
--- a/instruqt-tracks/network-external-ingress/01-http/assignment.md
+++ b/instruqt-tracks/network-external-ingress/01-http/assignment.md
@@ -1,0 +1,128 @@
+---
+slug: http
+id: cax2cdriaxvw
+type: challenge
+title: HTTP
+teaser: Learn how to expose a http server from a virtual machine.
+notes:
+- type: text
+  contents: |
+    # Learn about allowing external ingress
+
+    Sandboxes by default are not exposed to the public internet. However,
+    this behaviour can be changed for hosted Virtual Machines (VM) only.
+- type: text
+  contents: |
+    # Required Configuration
+
+    To allow external ingress traffic to a hosted VM add the
+    `allow_external_ingress` attribute to a tracks `config.yml` file.
+- type: text
+  contents: |
+    # HTTP external ingress option
+
+    One of the optional values that can be set is the `http` option. This allows
+    the exposure of an HTTP server hosted within the VM to the public internet.
+
+    We will learn how to gain access to the http server from the public internet.
+tabs:
+- title: Shell
+  type: terminal
+  hostname: external-ingress
+- title: Internal Website
+  type: service
+  hostname: external-ingress
+  port: 80
+- title: Broken Website
+  type: website
+  url: https://external-ingress.${_SANDBOX_ID}.instruqt.io
+difficulty: basic
+timelimit: 600
+---
+
+💡 Shell
+=========
+
+This virtual machine has an `nginx` server running. To confirm that it
+is running execute the following command:
+
+```bash
+systemctl is-active nginx
+```
+
+You should see the status: **active**.
+
+To check the different ports that the `nginx` server is running on use
+the following command:
+
+```bash
+ss -tulpn | grep nginx
+```
+
+We should confirm that the `nginx` server is currently **only listening
+on port 80** for incoming traffic.
+
+🕸 Internal Website
+=====================
+
+Have you noticed the internal website tab?
+
+Click this tab and ensure that you are able to see the internal
+website of cats 😺.
+
+This website is running on **port 80** currently. We would like to
+have this exposed to the public internet.
+
+To do this we need a `virtualmachines` addition to
+`config.yml` as follows:
+
+```yaml
+  allow_external_ingress:
+  - http
+```
+
+🚧 Broken Website
+==================
+
+Have you noticed the broken website tab as well?
+
+Clicking this tab will show a blank webpage instead of our
+cat website 🤕.
+
+This is because a website tab requires an HTTPS url to be embeded.
+However, our current cat website only serves requests over HTTP.
+
+We will learn how to resolve this in the next challenge. For now,
+in order for us to gain access to this http server we will have to
+connect to its external IP address from outside the sandbox.
+
+👀 External Website
+====================
+
+To connect to a sandbox VM from an external system, you'll need to
+know its external IP address.
+
+Instruqt adds two temporary DNS records for every sandbox virtual
+machine with `allow_external_ingress` enabled.
+
+Switch back to the **Shell** tab and execute the following command
+to access the external address:
+
+```bash
+echo http://$HOSTNAME.$_SANDBOX_ID.instruqt.io
+```
+
+Hover over the outputted link and click on it. This should open a
+separate unsecure browser tab with our cat website.
+
+🏁 Finish
+==========
+
+Hooray 🎉🎉!
+
+You have just learnt how to allow external ingress for http servers.
+
+You have also learnt how to externally access the server listening on
+port 80 within the VM from outside the sandbox environment.
+
+To complete the challenge, press **Next**.

--- a/instruqt-tracks/network-external-ingress/02-https/assignment.md
+++ b/instruqt-tracks/network-external-ingress/02-https/assignment.md
@@ -1,0 +1,91 @@
+---
+slug: https
+id: jvxcdsfwy9w2
+type: challenge
+title: HTTPS
+teaser: Learn how to expose a https server from a virtual machine.
+notes:
+- type: text
+  contents: |
+    # Learn about external ingress (recap)
+
+    We have learnt how adding the `http` optional value to the `allow_external_ingress` can
+    enable the exposure of a server listening on port 80 within a VM.
+- type: text
+  contents: |
+    # HTTPS external ingress option
+
+    What if the server is using the HTTPS protocol?
+
+    How can we expose that to the public internet as well?
+
+    Adding the `https` option to the `allow_external_ingress` attribute will allow us
+    to expose an HTTPS server hosted on port 443 within the VM to the public internet.
+tabs:
+- title: Shell
+  type: terminal
+  hostname: external-ingress
+- title: External Website
+  type: website
+  url: https://external-ingress.${_SANDBOX_ID}.instruqt.io
+difficulty: basic
+timelimit: 600
+---
+
+💡 Shell
+=========
+
+Again we can confirm that our `nginx` server is running:
+
+```bash
+systemctl is-active nginx
+```
+
+This time we also have a configured `nginx` server that can
+handle `https` inbound traffic. Executing the following
+command will confirm whether `https` traffic is allowed by
+showing all the `nginx` processes:
+
+```bash
+ss -tulpn | grep nginx
+```
+
+We should confirm that `nginx` is now **also listening to port 443**
+for incoming traffic.
+
+🕸 External Website
+====================
+
+Have you noticed the external website tab?
+
+Click this tab and ensure that you are able to see the external
+website of cats 😺. This version is served over `https`.
+
+The embeded website tab only works for `https` urls. We can not have
+an `http` website loaded within our sandbox. This is because the
+sandbox itself is served over `https`.
+
+To connect to the externally exposed VM server we would again need to
+know the external IP address.
+
+Switch back to the **Shell** tab and execute the following command to
+access the external address:
+
+```bash
+echo https://$HOSTNAME.$_SANDBOX_ID.instruqt.io
+```
+
+Hover over the outputted link and click on it. This should open a separate
+secure browser tab with our cat website.
+
+🏁 Finish
+==========
+
+Hooray 🎉🎉!
+
+You have just learnt how to allow external ingress for https servers.
+
+You have also learnt how to externally access the server listening on
+port 443 within the VM from outside the sandbox environment.
+
+To complete the challenge, press **Next**.

--- a/instruqt-tracks/network-external-ingress/02-https/setup-external-ingress
+++ b/instruqt-tracks/network-external-ingress/02-https/setup-external-ingress
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euxo pipefail
+
+echo "Running https challenge setup script"
+
+# We need to install certbot to allow us to
+# generate and serve certificates.
+snap install --classic certbot
+ln -s /snap/bin/certbot /usr/bin/certbot
+
+# Run certbot to get certificate for domain
+# along with editing the nginx configuration
+# to serve the certificate.
+certbot --nginx \
+  -d external-ingress.${_SANDBOX_ID}.instruqt.io \
+  -m chad@instruqt.com \
+  --agree-tos \
+  -n

--- a/instruqt-tracks/network-external-ingress/config.yml
+++ b/instruqt-tracks/network-external-ingress/config.yml
@@ -1,0 +1,9 @@
+version: "3"
+virtualmachines:
+- name: external-ingress
+  image: ubuntu-minimal-2004-lts
+  shell: /bin/bash
+  machine_type: n1-standard-1
+  allow_external_ingress:
+  - http
+  - https

--- a/instruqt-tracks/network-external-ingress/track.yml
+++ b/instruqt-tracks/network-external-ingress/track.yml
@@ -1,0 +1,23 @@
+slug: network-external-ingress
+id: wpxes9wdpepb
+type: track
+title: Virtual Machine with allow external ingress
+teaser: Allow external systems to communicate with a VM.
+description: |-
+  This template shows you how to configure a Virtual Machine (VM) that
+  allows external ingress.
+
+  **This track demonstrates how to:**
+  - Allow external ingress to a server using HTTP on **port 80**
+  - Allow external ingress to a server using HTTPS on **port 433**
+  - Embed exposed servers using the website tab
+icon: https://storage.googleapis.com/instruqt-frontend/img/tracks/instruqt.png
+tags:
+- introduction
+- instruqt
+owner: instruqt
+developers:
+- chad@instruqt.com
+private: true
+published: false
+checksum: "10042787652761433073"

--- a/instruqt-tracks/network-external-ingress/track_scripts/setup-external-ingress
+++ b/instruqt-tracks/network-external-ingress/track_scripts/setup-external-ingress
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euxo pipefail
+
+echo "Running track setup script"
+
+# Wait for the Instruqt host bootstrap to finish.
+until [ -f /opt/instruqt/bootstrap/host-bootstrap-completed ]
+do
+    sleep 1
+done
+
+# Here we are installing the nginx package. The noninteractive setting ensures
+# that the apt command won't stop and ask for user input.
+apt -y update
+DEBIAN_FRONTEND=noninteractive apt -y install nginx
+
+# Remove the default nginx landing page and replace
+# it with something more useful.
+rm /var/www/html/index.nginx-debian.html
+cat >> /var/www/html/index.html <<-EOF
+<html>
+  <head><title>Meow!</title></head>
+  <body>
+  <div style="width:800px;margin: 0 auto">
+  <!-- BEGIN -->
+  <center><img src="http://placekitten.com/640/480"></img></center>
+  <center><h2>Meow World!</h2></center>
+  <center>Welcome to the Meow World application. Meow! =^._.^=</center>
+  <!-- END -->
+  </div>
+  </body>
+</html>
+EOF
+
+# Start up the nginx service.
+service nginx start


### PR DESCRIPTION
This adds a template that showcases how to make use of the `allow_external_ingress` Virtual Machine feature.

In this template we have 2 challenges each challenge walks through the two different options that are available to make use of namely `http` and `https`.

The VM we spin up has a web server running -using Nginx. We show how having this feature enabled allows one to generate publicly exposable URLs to the associated servers running on port 80 for http and port 443 for https.

This track has been pushed to both prod and dev to test that this works as expected.

Links to both environments are as follows:

[play.instruqt.dev/instruqt/tracks/network-external-ingress](https://play.instruqt.dev/instruqt/tracks/network-external-ingress)
[play.instruqt.com/instruqt/tracks/network-external-ingress](https://play.instruqt.com/instruqt/tracks/network-external-ingress)