### PR TITLE
Include external ingress track to github workflows and fix action typo

### DIFF
--- a/.github/actions/instruqt-track-push/action.yml
+++ b/.github/actions/instruqt-track-push/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - name: Run track validate
+  - name: Run track push
     shell: bash
     run: |
       cd ${{ inputs.path }}

--- a/.github/workflows/validate-push-test.yml
+++ b/.github/workflows/validate-push-test.yml
@@ -32,10 +32,11 @@ jobs:
         - aws-cloud-account
         - container
         - docker-vm
+        - helm
         - kubernetes
         - kubernetes-cluster
+        - network-external-ingress
         - vscode-typescript
-        - helm
     steps:
       - run: echo "📝 Instruqt validate/push/test job was triggered by a ${{ github.event_name }} event."
       - name: Check out repository code


### PR DESCRIPTION
This changes adds the new `network-external-ingress` track to the GitHub workflow to run validation and deployment actions on.

This change updates the order of the tracks in the workflow to be in alphabetical order as well by moving up the `helm` track to the correct position as well.

The push action also had a name typo referring to the run step as a `Validation` step rather than a `Push` step. This might be the cause of some confusion when viewing the GitHub action logs.