### PR TITLE
Update the network external ingress track to published

### DIFF
--- a/instruqt-tracks/network-external-ingress/track.yml
+++ b/instruqt-tracks/network-external-ingress/track.yml
@@ -18,6 +18,6 @@ tags:
 owner: instruqt
 developers:
 - chad@instruqt.com
-private: true
-published: false
+private: false
+published: true
 checksum: "10042787652761433073"


### PR DESCRIPTION
This change updates the `network external ingress` track has both:
- `Public` ✅
- `Published` ✅

This will only be merged into main once the previous pull request (#33) has also be merged. 