### PR TITLE
Update network external ingress to template owner

### DIFF
--- a/instruqt-tracks/network-external-ingress/track.yml
+++ b/instruqt-tracks/network-external-ingress/track.yml
@@ -1,5 +1,4 @@
 slug: network-external-ingress
-id: wpxes9wdpepb
 type: track
 title: Virtual Machine with allow external ingress
 teaser: Allow external systems to communicate with a VM.
@@ -15,7 +14,7 @@ icon: https://storage.googleapis.com/instruqt-frontend/img/tracks/instruqt.png
 tags:
 - introduction
 - instruqt
-owner: instruqt
+owner: templates
 developers:
 - chad@instruqt.com
 private: true


### PR DESCRIPTION
This change updates the owner of the `network external ingress` template to `templates` this should prevent the GitHub push action from falling with the `Unauthorised` error.

This also removes the `id` value from the track as it seems like most tracks has this removed. We should probably push a separate diff to remove it from the others that still have them listed.