### PR TITLE
Use Node.js 20.x LTS

### DIFF
--- a/instruqt-tracks/vscode-typescript/01-passing-tests/setup-container
+++ b/instruqt-tracks/vscode-typescript/01-passing-tests/setup-container
@@ -11,7 +11,7 @@ EOF
 
 # Install Node.js
 # https://github.com/nodesource/distributions/blob/master/README.md
-curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
+curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
 apt-get install -y nodejs
 
 # Clone the example repository


### PR DESCRIPTION
Current setup script uses Node 14.x, which is so old the setup script spends 80 seconds waiting for user input due to deprecation/migration warnings. This also breaks installation of `npm`

This change addresses both issues.